### PR TITLE
Fix issue loading wrong days

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -361,7 +361,7 @@ class _APIRequest {
 
   Future <String> getIDForRPlanDay(APIAction action) async {
     String response = await _APIConnection.getFromAPI(
-        "vplans", null, _user.getJWT());
+        "vplans", {"date": "gte-${(new DateTime.now().millisecondsSinceEpoch ~/ 1000) - 86400}"}, _user.getJWT());
     var jsonResponse = jsonDecode(response)["entities"];
     if (action == APIAction.GET_RPLAN_TODAY) {
       return jsonResponse[0]["id"];


### PR DESCRIPTION
Fix issue loading wrong days in rplan/vplan by requesting only new dates from the API
![grafik](https://user-images.githubusercontent.com/24608706/70567257-dff9f980-1b95-11ea-9c37-93a288035eba.png)
(Proof that newest Date is shown)