### PR TITLE
:recycle: Generate App Pages and App Bar based on App type

### DIFF
--- a/lib/Views/Login.dart
+++ b/lib/Views/Login.dart
@@ -166,17 +166,3 @@ class LoginState extends State<Login>
   @override
   bool get wantKeepAlive => true;
 }
-
-class NotLoggedIn extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(),
-      body: Center(
-        child: ElevatedButton(
-            onPressed: () => KAGAppState.app.goToPage(3),
-            child: Text("Bitte melde dich an!", style: TextStyle(color: Colors.white))),
-      ),
-    );
-  }
-}

--- a/lib/Views/User.dart
+++ b/lib/Views/User.dart
@@ -26,7 +26,7 @@ class User extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         content: Text("Logged out!"),
         action: SnackBarAction(
-            label: 'Zurück zum Start!', onPressed: () => KAGAppState.app.goToPage(2))
+            label: 'Zurück zum Start!', onPressed: () => KAGAppState.app.goToPage(0))
     ));
   }
 

--- a/lib/Views/Views.dart
+++ b/lib/Views/Views.dart
@@ -8,28 +8,71 @@ import './RPlan.dart'     as RPlan; // ignore: library_prefixes
 import './User.dart'      as User; // ignore: library_prefixes
 import './WebMail.dart'   as WebMail; // ignore: library_prefixes
 
+import '../main.dart';
+
 /// Used by main.dart
 ///
 
 // ignore: non_constant_identifier_names
-List<Widget> AppViews({bool loggedIn = true, bool webmail = false}) {
-  var widgets = <Widget>[
-    new Calendar.Calendar(),
-    loggedIn ? new RPlan.RPlanViewWidget() : new Login.NotLoggedIn(),
-    new Home.Home(),
-    loggedIn ? new User.User() : new Login.Login(),
-    new News.News(),
-  ];
-  if (webmail) {
-    widgets.add(WebMail.WebMail());
+List<Widget> AppViews(AppType type) {
+  switch (type) {
+    case AppType.LOGGED_OUT:
+      return <Widget>[
+        new Home.Home(),
+        new Calendar.Calendar(),
+        new News.News(),
+        new Login.Login(),
+      ];
+    case AppType.NORMAL:
+    case AppType.NORMAL_WITH_WEBMAIL:
+      return <Widget>[
+        new Home.Home(),
+        new Calendar.Calendar(),
+        new RPlan.RPlanViewWidget(),
+        new User.User(),
+        if (type == AppType.NORMAL_WITH_WEBMAIL) WebMail.WebMail(),
+        new News.News(),
+      ];
+    case AppType.VPLAN_LOGGED_OUT:
+      return <Widget>[
+        new Login.Login(),
+      ];
+    case AppType.VPLAN:
+      return <Widget>[
+        new RPlan.RPlanViewWidget(),
+        new User.User(),
+      ];
+    case AppType.MOBILE_SITE:
+      return <Widget>[
+        new News.News(),
+        new Calendar.Calendar(),
+        new Login.Login(),
+      ];
   }
-  return widgets;
+
+  return <Widget>[];
 }
 
-// ignore: non_constant_identifier_names
-List<Widget> VPlanAppViews({bool loggedIn = true}) {
-  return <Widget>[
-    loggedIn ? new RPlan.RPlanViewWidget() : new Login.Login(),
-    loggedIn ? new User.User() : new Login.Login(),
-  ];
+int getPageCount(AppType type) {
+  switch (type) {
+    case AppType.LOGGED_OUT:
+      return 4;
+      break;
+    case AppType.NORMAL:
+      return 5;
+      break;
+    case AppType.NORMAL_WITH_WEBMAIL:
+      return 6;
+      break;
+    case AppType.VPLAN_LOGGED_OUT:
+      return 1;
+      break;
+    case AppType.VPLAN:
+      return 2;
+      break;
+    case AppType.MOBILE_SITE:
+      return 3;
+      break;
+  }
+  return 0;
 }

--- a/lib/components/menu.dart
+++ b/lib/components/menu.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:package_info/package_info.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../main.dart';
+
 class ExtraOptionsMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -66,53 +68,101 @@ class ExtraOptionsMenu extends StatelessWidget {
 }
 
 class BottomNavigationBarMenu extends StatelessWidget {
-  BottomNavigationBarMenu({this.isVPlanApp = false, this.webmail = false, this.controller});
+  BottomNavigationBarMenu(this.type, this.controller);
 
-  final bool isVPlanApp;
-  final bool webmail;
   final TabController controller;
+  final AppType type;
 
   @override
   Widget build(BuildContext context) {
-    var widgets = isVPlanApp ? <Widget>[
-      Tab(
-        text: "VPlan",
-        icon: Icon(Icons.compare_arrows),
-      ),
-      Tab(
-        text: "SPlan",
-        icon: Icon(Icons.person),
-      ),
-    ] :
-    // Normal App
-    <Widget>[
-      Tab(
-        text: "Termine",
-        icon: Icon(Icons.event),
-      ),
-      Tab(
-        text: "VPlan",
-        icon: Icon(Icons.compare_arrows),
-      ),
-      Tab(
-        text: "Home",
-        icon: Icon(Icons.home),
-      ),
-      Tab(
-        text: "User",
-        icon: Icon(Icons.person),
-      ),
-      Tab(
-        text: "News",
-        icon: Icon(Icons.public),
-      ),
-    ];
+    List<Widget> widgets = [];
 
-    if (webmail) {
-      widgets.add(Tab(
-        text: "Mail",
-        icon: Icon(Icons.email),
-      ));
+    switch (type) {
+      case AppType.LOGGED_OUT:
+        widgets = [
+          Tab(
+            text: "Home",
+            icon: Icon(Icons.home, size: 35),
+          ),
+          Tab(
+            text: "Termine",
+            icon: Icon(Icons.event, size: 35),
+          ),
+          Tab(
+            text: "News",
+            icon: Icon(Icons.public, size: 35),
+          ),
+          Tab(
+            text: "Login",
+            icon: Icon(Icons.person, size: 35),
+          )
+        ];
+        break;
+      case AppType.NORMAL:
+      case AppType.NORMAL_WITH_WEBMAIL:
+        widgets = [
+          Tab(
+            text: "Home",
+            icon: Icon(Icons.home, size: 35),
+          ),
+          Tab(
+            text: "Termine",
+            icon: Icon(Icons.event, size: 35),
+          ),
+          Tab(
+            text: "VPlan",
+            icon: Icon(Icons.swap_horiz, size: 35),
+          ),
+          Tab(
+            text: "User",
+            icon: Icon(Icons.person, size: 35),
+          ),
+          if (type == AppType.NORMAL_WITH_WEBMAIL) Tab(
+            text: "Mail",
+            icon: Icon(Icons.mail, size: 35),
+          ),
+          Tab(
+            text: "News",
+            icon: Icon(Icons.public, size: 35),
+          ),
+        ];
+        break;
+      case AppType.VPLAN_LOGGED_OUT:
+        widgets = [
+          Tab(
+            text: "Login",
+            icon: Icon(Icons.person, size: 35),
+          ),
+        ];
+        break;
+      case AppType.VPLAN:
+        widgets = [
+          Tab(
+            text: "VPlan",
+            icon: Icon(Icons.swap_horiz, size: 35),
+          ),
+          Tab(
+            text: "SPlan",
+            icon: Icon(Icons.person, size: 35),
+          ),
+        ];
+        break;
+      case AppType.MOBILE_SITE:
+        widgets = [
+          Tab(
+            text: "News",
+            icon: Icon(Icons.public, size: 35),
+          ),
+          Tab(
+            text: "Termine",
+            icon: Icon(Icons.event, size: 35),
+          ),
+          Tab(
+            text: "Login",
+            icon: Icon(Icons.person, size: 35),
+          ),
+        ];
+        break;
     }
 
     return Container(
@@ -133,47 +183,92 @@ class BottomNavigationBarMenu extends StatelessWidget {
 }
 
 // ignore: avoid_positional_boolean_parameters
-List<NavigationRailDestination> getNavigationRail(bool isVPlanApp, bool webmail) {
-  if (isVPlanApp) {
-    return <NavigationRailDestination>[
-      NavigationRailDestination(
-        label: Text("VPlan"),
-        icon: Icon(Icons.compare_arrows, size: 35),
-      ),
-      NavigationRailDestination(
-        label: Text("SPlan"),
-        icon: Icon(Icons.person, size: 35),
-      ),
-    ];
-  } else {
-    var icons = <NavigationRailDestination>[
-      NavigationRailDestination(
-        label: Text("Termine"),
-        icon: Icon(Icons.event, size: 35),
-      ),
-      NavigationRailDestination(
-        label: Text("VPlan"),
-        icon: Icon(Icons.compare_arrows, size: 35),
-      ),
-      NavigationRailDestination(
-        label: Text("Home"),
-        icon: Icon(Icons.home, size: 35),
-      ),
-      NavigationRailDestination(
-        label: Text("User"),
-        icon: Icon(Icons.person, size: 35),
-      ),
-      NavigationRailDestination(
-        label: Text("News"),
-        icon: Icon(Icons.public, size: 35),
-      ),
-    ];
-    if (webmail) {
-      icons.add(NavigationRailDestination(
-        label: Text("Mail"),
-        icon: Icon(Icons.mail, size: 35),
-      ));
-    }
-    return icons;
+List<NavigationRailDestination> getNavigationRail(AppType type) {
+  switch (type) {
+    case AppType.LOGGED_OUT:
+      return <NavigationRailDestination>[
+        NavigationRailDestination(
+          label: Text("Home"),
+          icon: Icon(Icons.home, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("Termine"),
+          icon: Icon(Icons.event, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("News"),
+          icon: Icon(Icons.public, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("Login"),
+          icon: Icon(Icons.person, size: 35),
+        )
+      ];
+    case AppType.NORMAL:
+    case AppType.NORMAL_WITH_WEBMAIL:
+      return <NavigationRailDestination>[
+        NavigationRailDestination(
+          label: Text("Home"),
+          icon: Icon(Icons.home, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("Termine"),
+          icon: Icon(Icons.event, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("VPlan"),
+          icon: Icon(Icons.swap_horiz, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("User"),
+          icon: Icon(Icons.person, size: 35),
+        ),
+        if (type == AppType.NORMAL_WITH_WEBMAIL) NavigationRailDestination(
+          label: Text("Mail"),
+          icon: Icon(Icons.mail, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("News"),
+          icon: Icon(Icons.public, size: 35),
+        ),
+      ];
+    case AppType.VPLAN_LOGGED_OUT:
+      return <NavigationRailDestination>[
+        NavigationRailDestination(
+          label: Text("Login"),
+          icon: Icon(Icons.person, size: 35),
+        ),
+        NavigationRailDestination( // We need this here as Flutter does not allow having only one item
+          label: Text("Login"),
+          icon: Icon(Icons.swap_horiz, size: 35),
+        ),
+      ];
+    case AppType.VPLAN:
+      return <NavigationRailDestination>[
+        NavigationRailDestination(
+          label: Text("VPlan"),
+          icon: Icon(Icons.swap_horiz, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("SPlan"),
+          icon: Icon(Icons.person, size: 35),
+        ),
+      ];
+    case AppType.MOBILE_SITE:
+      return <NavigationRailDestination>[
+        NavigationRailDestination(
+          label: Text("News"),
+          icon: Icon(Icons.public, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("Termine"),
+          icon: Icon(Icons.event, size: 35),
+        ),
+        NavigationRailDestination(
+          label: Text("Login"),
+          icon: Icon(Icons.person, size: 35),
+        ),
+      ];
   }
+  return <NavigationRailDestination>[];
 }


### PR DESCRIPTION
Diese PR sorgt dafür, dass die App Bar (und Navigation Rail) und die Seiten der nicht mehr auf variablen aufgebaut werden, sondern verständlich mir einer Variable.

Außerdem wird Support für die neue "mobile Seite" hinzugefügt.

### Typ

- Neues Feature / Erweiterung eines Features

### Implementation
Hierbei war die Idee, dass die mobile Seite hauptsächlich an externe angepasst ist und nicht die Home Seite der App anzeigt.
Gleichzeitig sollte diese für SuS weiterhin sichtbar sein.

### Checklist
- [ ] Ich habe die Tests erweitert um zu zeigen, dass der Bugfix/das Feature funktioniert
- [x] Der neue Code hält sich an die Coding Standards
- [x] Im Code befinden sich wichtige Kommentare, falls angemessen