### PR TITLE
:sparkles: Show in calendar that there are multiple events

### DIFF
--- a/lib/Views/Calendar.dart
+++ b/lib/Views/Calendar.dart
@@ -270,13 +270,12 @@ class _TableCalendarState extends State<_TableCalendar> with TickerProviderState
   // Builds the list before a day has been selected
   Widget _buildEventsList(List events) {
     if (events == null) return Text("");
-    List<Widget> eventWidgets = [];
-    for (var event in events) {
-      eventWidgets.add(Text(event.title, style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 14 : 9),));
+    if (events.length == 1) {
+      return Text(events[0].title, style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 13 : 9), textAlign: TextAlign.left);
+    } else if (events.length > 1) {
+      return Text("Mehrere Termine", style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 13 : 9, fontStyle: FontStyle.italic), textAlign: TextAlign.left);
     }
-    return Column(
-      children: eventWidgets,
-    );
+    return Container();
   }
 
 

--- a/lib/Views/Calendar.dart
+++ b/lib/Views/Calendar.dart
@@ -248,18 +248,26 @@ class _TableCalendarState extends State<_TableCalendar> with TickerProviderState
   }
 
   Widget _buildDay(date, events, {today=false}) {
+    var isLandscape = MediaQuery.of(context).orientation == Orientation.landscape;
     return Container(
-      margin: const EdgeInsets.all(4.0),
-      padding: const EdgeInsets.only(top: 5.0, left: 6.0),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Theme.of(context).colorScheme.secondary),
+      ),
+      margin: EdgeInsets.all(isLandscape ? 4 : 1.5),
+      padding: const EdgeInsets.only(top: 5.0, left: 5.0, right: 5.0),
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
-            padding: const EdgeInsets.all(3.0),
-            decoration: today ? new BoxDecoration(borderRadius: new BorderRadius.circular(16.0), color: Theme.of(context).colorScheme.secondary) : null,
-            child:
-          Text(
+            alignment: Alignment.topCenter,
+            padding: const EdgeInsets.all(1.0),
+            decoration: today ? new BoxDecoration(borderRadius: new BorderRadius.circular(16.0), color: Theme.of(context).colorScheme.primary) : null,
+            child: Text(
               '${date.day}',
-              style: TextStyle().copyWith(fontSize: 16.0)),
+              style: TextStyle().copyWith(fontSize: isLandscape ? 16 : 10, color: today ? Colors.white : Colors.black)
+            ),
           ),
           _buildEventsList(events)
         ],
@@ -271,9 +279,9 @@ class _TableCalendarState extends State<_TableCalendar> with TickerProviderState
   Widget _buildEventsList(List events) {
     if (events == null) return Text("");
     if (events.length == 1) {
-      return Text(events[0].title, style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 13 : 9), textAlign: TextAlign.left);
+      return Expanded(child: Text(events[0].title, style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 13 : 9), textAlign: TextAlign.left));
     } else if (events.length > 1) {
-      return Text("Mehrere Termine", style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 13 : 9, fontStyle: FontStyle.italic), textAlign: TextAlign.left);
+      return Expanded(child: Text("Mehrere Termine", style: TextStyle().copyWith(fontSize: MediaQuery.of(context).size.longestSide > 1000 ? 13 : 9, fontStyle: FontStyle.italic), textAlign: TextAlign.left));
     }
     return Container();
   }

--- a/lib/Views/Calendar.dart
+++ b/lib/Views/Calendar.dart
@@ -42,19 +42,27 @@ class _Calendar extends StatelessWidget {
       stream: controller.stream,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
+          if (MediaQuery.of(context).size.height < 600) {
+            return Scaffold(
+              appBar: AppBar(
+                title: Text("Termine"),
+              ),
+              body: _ListCalendar(),
+            );
+          }
           return Scaffold(
               appBar: AppBar(
-                  title: Text("Termine"),
-                  actions: [Padding(padding: EdgeInsets.all(10),
-                  child: ElevatedButton(
-                      onPressed: () => _switchView(!snapshot.data),
-                      child: Container(
-                        child: Text(snapshot.data ? "Als Kalender" : "Als Liste",
-                            style: TextStyle(fontSize: 15, color: Colors.white)),
-                        margin: EdgeInsets.fromLTRB(10, 0, 10, 0),
-                        alignment: Alignment.centerRight,
-                      )
-                  ))],
+                title: Text("Termine"),
+                actions: [Padding(padding: EdgeInsets.all(10),
+                    child: ElevatedButton(
+                        onPressed: () => _switchView(!snapshot.data),
+                        child: Container(
+                          child: Text(snapshot.data ? "Als Kalender" : "Als Liste",
+                              style: TextStyle(fontSize: 15, color: Colors.white)),
+                          margin: EdgeInsets.fromLTRB(10, 0, 10, 0),
+                          alignment: Alignment.centerRight,
+                        )
+                    ))],
               ),
               body: snapshot.data ? _ListCalendar() : _TableCalendar());
         } else {


### PR DESCRIPTION

### Typ
- Neues Feature / Erweiterung eines Features

### Implementation
Bei mehreren Terminen an einem Tag im Kalender nur anzeigen, dass es mehrere gibt

### Checklist

_Alle erfüllten Boxen ankreuzen. Diese Liste kann auch nach Erstellung der Pull Request vervollständigt werden. Unter diesen Gesichtspunkten wird die Implementation begutachtet._

- [ ] Ich habe die Tests erweitert um zu zeigen, dass der Bugfix/das Feature funktioniert
- [ ] Der neue Code hält sich an die Coding Standards
- [ ] Im Code befinden sich wichtige Kommentare, falls angemessen