### PR TITLE
Erlaube app Zulip zu öffnen

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -23,6 +23,8 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>moodlemobile</string>
+		<string>zulip</string>
+		<string>nextcloud</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
### Typ
- Bugfix

### Implementation
In info.plist hinzugefügt, damit auch Zulip vom Homescreen geöffnet werden darf

### Checklist

_Alle erfüllten Boxen ankreuzen. Diese Liste kann auch nach Erstellung der Pull Request vervollständigt werden. Unter diesen Gesichtspunkten wird die Implementation begutachtet._

- [ ] Ich habe die Tests erweitert um zu zeigen, dass der Bugfix/das Feature funktioniert
- [x] Der neue Code hält sich an die Coding Standards
- [ ] Im Code befinden sich wichtige Kommentare, falls angemessen