### PR TITLE
Flutter fcm upgraden

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -175,42 +175,42 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.4"
+    version: "4.2.5"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.6.2"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.0.0"
+    version: "11.2.15"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.3.1"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.13"
   fixnum:
     dependency: transitive
     description:
@@ -708,5 +708,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  firebase_messaging: 10.0.0
-  firebase_core: ^1.2.0
+  firebase_messaging: ^11.2.15
+  firebase_core: ^1.13.1
   flip_panel: ^1.0.1
   open_file: ^3.2.1
   package_info: ^2.0.2


### PR DESCRIPTION
### Typ
- Bugfix

### Implementation
Flutter fcm needed to be upgraded to still support the android
embedding. We could not load the fcm token and could not
subscribe to topics.


### Checklist

_Alle erfüllten Boxen ankreuzen. Diese Liste kann auch nach Erstellung der Pull Request vervollständigt werden. Unter diesen Gesichtspunkten wird die Implementation begutachtet._

- [ ] Ich habe die Tests erweitert um zu zeigen, dass der Bugfix/das Feature funktioniert
- [x] Der neue Code hält sich an die Coding Standards
- [x] Im Code befinden sich wichtige Kommentare, falls angemessen
