### PR TITLE
:bug: Fix UserPreloadCache not being cleared on logout

### DIFF
--- a/lib/Views/User.dart
+++ b/lib/Views/User.dart
@@ -22,7 +22,9 @@ class User extends StatelessWidget {
   static void logout(BuildContext context) {
     API.of(context).setLoginCredentials(null, null);
     KAGAppState.app.setLoggedOut();
-    SharedPreferences.getInstance().then((instance) => instance.remove("klasse"));
+    SharedPreferences.getInstance().then((instance) {
+      instance.remove(SP_CACHE_USER_PRELOAD);
+    });
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         content: Text("Logged out!"),
         action: SnackBarAction(


### PR DESCRIPTION
## Commit
We need to clear the UserPreloadCache on logout
to not store personal information after logout.

**Close #160 **

### Typ

- Bugfix

### Implementation
In eine der Logout Methoden einfügen...

### Checklist

_Alle erfüllten Boxen ankreuzen. Diese Liste kann auch nach Erstellung der Pull Request vervollständigt werden. Unter diesen Gesichtspunkten wird die Implementation begutachtet._

- [ ] Ich habe die Tests erweitert um zu zeigen, dass der Bugfix/das Feature funktioniert
- [ ] Der neue Code hält sich an die Coding Standards
- [ ] Im Code befinden sich wichtige Kommentare, falls angemessen