### PR TITLE
 Replace old ascii art arrow with icon

### DIFF
--- a/lib/components/rplan_components.dart
+++ b/lib/components/rplan_components.dart
@@ -199,7 +199,18 @@ class MobileLesson extends StatelessWidget {
                     children: [
                       Expanded(child: Visibility(
                         visible: RPlan.of(context).hasTeacherPlan,
-                        child: Text("${lesson.lehrer != null ? "${lesson.lehrer} -> " : ""}${lesson.v_lehrer == null || lesson.v_lehrer == "" ? "-" : lesson.v_lehrer}", style: normalText, textAlign: TextAlign.left),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            // need to be expanded for the arrow to be consistent in rows
+                            Expanded(child: Text(lesson.lehrer != null ? lesson.lehrer : "", style: normalText, textAlign: TextAlign.left)),
+                            Padding(
+                              child: Icon(Icons.arrow_forward, size: 20),
+                              padding: EdgeInsets.fromLTRB(0, 4, 0, 0),
+                            ),
+                            Expanded(child: Text(lesson.v_lehrer == null || lesson.v_lehrer == "" ? "-" : lesson.v_lehrer, style: normalText, textAlign: TextAlign.center))
+                          ],
+                        ),
                       )),
                       Expanded(child: Visibility(
                         visible: !RPlan.of(context).hasTeacherPlan,


### PR DESCRIPTION
### Commit
We still did use a ascii art arrow in the rplan mobile
overview. This commit replaces that with an icon.

### Typ


- Bugfix

### Checklist

_Alle erfüllten Boxen ankreuzen. Diese Liste kann auch nach Erstellung der Pull Request vervollständigt werden. Unter diesen Gesichtspunkten wird die Implementation begutachtet._

- [ ] Ich habe die Tests erweitert um zu zeigen, dass der Bugfix/das Feature funktioniert
- [x] Der neue Code hält sich an die Coding Standards
- [x] Im Code befinden sich wichtige Kommentare, falls angemessen